### PR TITLE
Remove BinaryTopic

### DIFF
--- a/src/change.ts
+++ b/src/change.ts
@@ -80,8 +80,6 @@ export abstract class Change<T> {
                 return new ListChangeTypes.Insert(topic,rest.index, rest.value, rest.id);
             case ListChangeTypes.Pop:
                 return new ListChangeTypes.Pop(topic,rest.index, rest.id);
-            case BinaryChangeTypes.Set:
-                return new BinaryChangeTypes.Set(topic, rest.value, rest.old_value, rest.id)
             default:
                 throw new Error(`Unknown change type: ${topic.getTypeName()} ${type}`);
         }
@@ -89,7 +87,7 @@ export abstract class Change<T> {
 }
 
 import deepcopy from "deepcopy";
-import {BinaryTopic, Topic} from "./topic";
+import { Topic } from "./topic";
 import { print } from "./devUtils"
 
 interface SetChangeDict extends ChangeDict {
@@ -102,8 +100,7 @@ class SetChange<T> extends Change<T> {
     value: T;
     oldValue?: T; 
 
-    // Change doesn't care of TI but only T of a topic, so we use any in TI
-    constructor(topic:Topic<T, any> ,value: T, old_value?: T, id?: string) {
+    constructor(topic:Topic<T> ,value: T, old_value?: T, id?: string) {
         super(topic,id);
         this.value = value;
         this.oldValue = old_value;
@@ -510,8 +507,4 @@ export namespace EventChangeTypes{
             throw new Error("Cannot inverse an emit change");
         }
     }
-}
-
-export namespace BinaryChangeTypes {
-    export const Set = SetChange<string>;
 }

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -10,8 +10,7 @@ import {
     GenericChangeTypes,
     EventChangeTypes,
     DictChangeTypes,
-    ListChangeTypes,
-    BinaryChangeTypes
+    ListChangeTypes
 } from './change';
 import {StateManager} from './stateManager';
 import deepcopy from 'deepcopy';
@@ -35,8 +34,7 @@ export abstract class Topic<T,TI=T>{
             set: SetTopic,
             dict: DictTopic,
             list: ListTopic,
-            event: EventTopic,
-            binary: BinaryTopic
+            event: EventTopic
         }
     }
     static GetTypeFromName(name: string): { new(name: string, stateManager: StateManager): Topic<any>; }{
@@ -208,6 +206,14 @@ export class StringTopic extends Topic<string>{
 
     public set(value: string): void{
         this.applyChangeExternal(new StringChangeTypes.Set(this,value));
+    }
+
+    public setFromBinary(data: Buffer) {
+        this.set(data.toString('base64'))
+    }
+
+    public toBinary(): Buffer {
+        return Buffer.from(this.getValue(), 'base64')
     }
 }
 
@@ -493,24 +499,4 @@ export class EventTopic extends Topic<null>{
             throw new Error(`Unsupported change type ${change} for ${this.constructor.name}`);
         }
     }
-}
-
-export class BinaryTopic extends Topic<string, Buffer> {
-
-    get base64(): string {
-        return this.value;
-    }
-
-    protected _getValue(): Buffer {
-        return Buffer.from(this.value, 'base64');
-    }
-
-    readonly changeTypes: { [p: string]: ConstructorOfChange<string> };
-
-    set(value: Buffer): void {
-        this.applyChangeExternal(new BinaryChangeTypes.Set(this, value.toString('base64')))
-    }
-
-    protected value: string;
-
 }


### PR DESCRIPTION
1. Remove BinaryTopic, the responsibility is moved to StringTopic's new method toBinary and setFromBinary
2. Remove BinaryChangeTypes

This pr pairs with https://github.com/eri24816/ChatRoom/pull/8